### PR TITLE
Change typescript compiler options to support ie11

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,15 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2015",
+    "module": "es2015",
+    "target": "es5",
     "declaration": true,
     "noImplicitAny": true,
     "outDir": "./dist",
-    "strict": true
+    "strict": true,
+    "lib": [
+      "es2016",
+      "dom"
+    ]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
We want to use JsonDecoder in a project that has IE11 support.
The current typescript compiler configuration is not fully compatible with the javascript support of IE11.
Therefore I've adjusted the tsconfig.