### PR TITLE
feat(allOf): add allOf decoder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "prettier.singleQuote": true,
   "editor.tabSize": 2
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.formatOnSave": true,
   "prettier.singleQuote": true,
+  "prettier.trailingComma": "none",
   "editor.tabSize": 2
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "prettier.singleQuote": true,
   "editor.tabSize": 2
 }

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ JsonDecoder.dictionary(JsonDecoder.number, 'Dict<number>').decode({
 
 > `oneOf<a>(decoders: Array<Decoder<a>>, decoderName: string): Decoder<a>`
 
-The `oneOf` decoder tries to decode the provided JSON with a collection of decoders. It returns `Ok` with the first successful decoded value or `Err` if all decoders fail.
+The `oneOf` decoder tries to decode the provided JSON with any of the provided decoders. It returns `Ok` with the first successful decoded value or `Err` if all decoders fail.
 
 #### @param `decoders: Array<Decoder<a>>`
 
@@ -257,6 +257,50 @@ JsonDecoder.oneOf<string | number>(
   'string | number'
 ).decode(true);
 // Output: Err({error: "<string | number> decoder failed because true can't be decoded with any of the provided oneOf decoders"})
+```
+
+### JsonDecoder.allOf
+
+> `allOf<T extends Array<Decoder<unknown>>, R = AllOfDecoderReturn<T>>(decoders: T): Decoder<R>`
+
+The `allOf` decoder tries to decode the provided JSON with all of the provided decoders, in order. The output of one decoder is passed as input to the next decoder. It returns `Ok` with the last successful decoded value or `Err` if any decoder fails.
+
+The `allOf` decoder allows you to combine multiple decoders. It is probably most useful when combined with custom decoders you may make for your application.
+
+#### @param `decoders: T extends Array<Decoder<unknown>>`
+
+An array of decoders that the JSON should be decoded with.
+
+Simple examples:
+
+```ts
+JsonDecoder.allOf(
+  JsonDecoder.string,
+  JsonDecoder.failover(10, JsonDecoder.number)
+).decode('hola'),
+// Output: Ok({value: 10})
+
+JsonDecoder.allOf(
+  JsonDecoder.string,
+  JsonDecoder.failover(10, JsonDecoder.number)
+).decode(5),
+// Output: Err({error: "5 is not a valid string})
+```
+
+Example using a custom `hasLength()` decoder (_assume this custom `hasLength()` decoder ensures an array is of a specific length_):
+
+```ts
+JsonDecoder.allOf(
+  JsonDecoder.array(JsonDecoder.number, 'latLang'),
+  hasLength<[number, number]>(2)
+).decode([-123.34324, 23.454365]);
+// Output: Ok({value: [-123.34324, 23.454365]})
+
+JsonDecoder.allOf(
+  JsonDecoder.array(JsonDecoder.number, 'latLang'),
+  hasLength<[number, number]>(2)
+).decode([1, 2, 3]);
+// Output: Err({error: "hasLength() decoder failed because the provided array is of length 3."})
 ```
 
 ### JsonDecoder.lazy

--- a/src/json-decoder.spec.ts
+++ b/src/json-decoder.spec.ts
@@ -173,6 +173,37 @@ describe('json-decoder', () => {
     });
   });
 
+  // allOf
+  describe('allOf', () => {
+    it('should be equivalent to the string decoder', () => {
+      expectOkWithValue(
+        JsonDecoder.allOf(JsonDecoder.string).decode('hola'),
+        'hola'
+      );
+    });
+    it('should return output from the last decoder', () => {
+      expectOkWithValue(
+        JsonDecoder.allOf(
+          JsonDecoder.string,
+          JsonDecoder.failover(10, JsonDecoder.number)
+        ).decode('hola'),
+        10
+      );
+    });
+    it('should fail if the first decoder fails', () => {
+      expectErrWithMsg(
+        JsonDecoder.allOf(JsonDecoder.string, JsonDecoder.number).decode(10),
+        $JsonDecoderErrors.primitiveError(10, 'string')
+      );
+    });
+    it('should fail if the last decoder fails', () => {
+      expectErrWithMsg(
+        JsonDecoder.allOf(JsonDecoder.string, JsonDecoder.number).decode('10'),
+        $JsonDecoderErrors.primitiveError('10', 'number')
+      );
+    });
+  });
+
   // object
   describe('object', () => {
     type User = {

--- a/src/json-decoder.ts
+++ b/src/json-decoder.ts
@@ -212,8 +212,9 @@ export namespace JsonDecoder {
   }
 
   /**
-   * Tries to decode the provided json value with all `decoders`.
-   * If all `decoders` fail the decoder fails, otherwise it returns the first successful decoder.
+   * Tries to decode the provided json value with any of the provided `decoders`.
+   * If all provided `decoders` fail, this decoder fails.
+   * Otherwise, it returns the first successful decoder.
    *
    * @param decoders An array of decoders to try.
    */
@@ -230,6 +231,71 @@ export namespace JsonDecoder {
       }
       return err<a>($JsonDecoderErrors.oneOfError(decoderName, json));
     });
+  }
+
+  type SubtractOne<T extends number> = [
+    -1,
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    29,
+    30
+  ][T];
+  
+  /**
+   * Plucks the last type in a tuple of length 30 or less.
+   * Else returns the first type in a tuple.
+   */
+  export type AllOfDecoderReturn<T extends unknown[]> = T[SubtractOne<
+    T['length']
+  >] extends JsonDecoder.Decoder<infer R>
+    ? R
+    : T[0];
+
+  /**
+   * Tries to decode the provided json value with all of the provided `decoders`.
+   * The order of the provided decoders matters: the output of one decoder is passed
+   * as input to the next decoder. If any of the provided `decoders` fail, this
+   * decoder fails. Otherwise, it returns the output of the last decoder.
+   *
+   * @param decoders a spread of decoders to use.
+   */
+  export function allOf<T extends Decoder<unknown>[], R = AllOfDecoderReturn<T>>(
+    ...decoders: T
+  ): Decoder<R> {
+    return new Decoder<R>((json: any) =>
+      decoders.reduce(
+        (prev, curr) =>
+          (prev instanceof Ok ? curr.decode(prev.value) : prev) as Result<R>,
+        ok<R>(json)
+      ),
+    );
   }
 
   /**

--- a/src/json-decoder.ts
+++ b/src/json-decoder.ts
@@ -267,7 +267,7 @@ export namespace JsonDecoder {
     29,
     30
   ][T];
-  
+
   /**
    * Plucks the last type in a tuple of length 30 or less.
    * Else returns the first type in a tuple.
@@ -286,15 +286,16 @@ export namespace JsonDecoder {
    *
    * @param decoders a spread of decoders to use.
    */
-  export function allOf<T extends Decoder<unknown>[], R = AllOfDecoderReturn<T>>(
-    ...decoders: T
-  ): Decoder<R> {
+  export function allOf<
+    T extends Array<Decoder<unknown>>,
+    R = AllOfDecoderReturn<T>
+  >(...decoders: T): Decoder<R> {
     return new Decoder<R>((json: any) =>
       decoders.reduce(
         (prev, curr) =>
           (prev instanceof Ok ? curr.decode(prev.value) : prev) as Result<R>,
         ok<R>(json)
-      ),
+      )
     );
   }
 


### PR DESCRIPTION
This PR adds a new "allOf()" decoder. Similar to "oneOf()" this decoder accepts a spread of input decoders and pipes an input JSON value through each decoder in succession, returning the result. If any decoder fails, this decoder fails.

While this decode isn't particularly useful with the standard decoders included in this package, it is incredibly useful for anyone implementing their own custom decoders as it allows composing multiple decoders together. I figure this is a common enough scenario that it is appropriate to add this decoder to the list of standard decoders included in this package.

For example, in my own project I created a `hasLength()` decoder which will ensure that an input array is of a specific length. `allOf()` can be used to combine `JsonDecoder.array` and `hasLength()` to ensure that an input array matches a specific format and has a specific length. 

```ts
allOf(
  JsonDecoder.array(JsonDecoder.number, 'latLang'),
  hasLength(2),
)
```

I wasn't entirely sure how to handle the return type of `allOf()` as typescript currently doesn't cleanly support the logic required to accurately infer typing for `allOf()`. I decided to settle on a "type hack" which will correctly infer the return type so long as the input type is a tuple of length 30 or less. Otherwise, the user will need to supply the return type.