### PR TITLE
Result is a Functor now

### DIFF
--- a/src/json-decoder.spec.ts
+++ b/src/json-decoder.spec.ts
@@ -10,14 +10,15 @@ const expectOkWithValue = <a>(result: Result<a>, expectedValue: a) =>
   expect(result)
     .to.be.an.instanceof(Ok)
     .and.to.deep.equal({
-      value: expectedValue
+      value: expectedValue,
+      map: Ok.prototype.map
     });
 const expectErr = <a>(result: Result<a>) =>
   expect(result).to.be.an.instanceof(Err);
 const expectErrWithMsg = <a>(result: Result<a>, expectedErrorMsg: string) =>
   expect(result)
     .to.be.an.instanceof(Err)
-    .and.to.deep.equal({ error: expectedErrorMsg });
+    .and.to.deep.equal({ error: expectedErrorMsg, map: Err.prototype.map });
 
 // Tests
 describe('json-decoder', () => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,8 +1,16 @@
 export class Ok<a> {
   constructor(readonly value: a) {}
+
+  map<b>(fn: (a: a) => b): Result<b> {
+    return ok(fn(this.value));
+  }
 }
 export class Err {
   constructor(readonly error: string) {}
+
+  map<b>(fn: (a: any) => b): Result<b> {
+    return this;
+  }
 }
 export type Result<a> = Ok<a> | Err;
 


### PR DESCRIPTION
Add Fantasy Land-compliant `map()` methods for `Ok` and `Err`, for functional programming happiness.

I had to patch the test helper functions to account for instance methods. I could have sworn Chai was smart enough to ignore stuff on prototypes, but, 🤷‍♂.

The other, possibly more semantic option is to assert that `deep.equal(new Ok(expectedValue))` and `deep.equal(new Err(expectedErrorMsg))`. Your call.