### PR TITLE
Add support for decoding optional values

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,53 @@ treeDecoder.decode({
 // Output: Err({error: "<Node<string>> decoder failed at key 'children' with error: <Node<string>[] | isUndefined> decoder failed because null can't be decoded with any of the provided oneOf decoders"})
 ```
 
+### JsonDecoder.optional
+
+> `optional<a>(decoder: Decoder<a>): Decoder<a | undefined>`
+
+Creates a decoder that returns a default value on failure.
+
+#### @param `decoder: Decoder<a>`
+
+The decoder that the JSON will be decoded with if not `null` or `undefined`.
+
+```ts
+type User = {
+  firstname: string;
+  lastname: string;
+};
+const userDecoder = JsonDecoder.object<User>(
+  {
+    firstname: JsonDecoder.string,
+    lastname: JsonDecoder.string
+  },
+  'User'
+);
+
+const jsonOk = {
+  firstname: 'Damien',
+  lastname: 'Jurado'
+};
+userDecoder.decode(jsonOk);
+
+const jsonKo = {
+  firstname: null,
+  lastname: 'Satie'
+};
+JsonDecoder.optional(userDecoder).decode(null);
+// Output: Ok<User | undefined>({value: undefined})
+
+JsonDecoder.optional(userDecoder).decode(undefined);
+// Output: Ok<User | undefined>({value: undefined})
+
+JsonDecoder.optional(userDecoder).decode(jsonObjectOk);
+// Output: Ok<User | undefined>({value: {firstname: 'Damien', lastname: 'Jurado'}})
+
+JsonDecoder.optional(userDecoder).decode(jsonKo);
+// Output: Err({error: '<User> decoder failed at key "firstname" with error: null is not a valid string'})
+```
+
+
 ### JsonDecoder.failover
 
 > `failover<a>(defaultValue: a, decoder: Decoder<a>): Decoder<a>`

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ The `optional` decoder tries to decode the provided JSON with the provided decod
 
 #### @param `decoder: Decoder<a>`
 
-The decoder that the JSON will be decoded with if not `null` or `undefined`.
+The decoder that the JSON will be decoded with if the value is not `null` or `undefined`.
 
 ```ts
 type User = {

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ treeDecoder.decode({
 
 > `optional<a>(decoder: Decoder<a>): Decoder<a | undefined>`
 
-Creates a decoder that returns a default value on failure.
+The `optional` decoder tries to decode the provided JSON with the provided decoder if the json value is not `undefined` or `null`.  This decoder is to allow for an optional value in the TypeScript definition, while retaining the ability to give a detailed error message if the wrapped decoder fails.
 
 #### @param `decoder: Decoder<a>`
 
@@ -408,11 +408,13 @@ The decoder that the JSON will be decoded with if not `null` or `undefined`.
 type User = {
   firstname: string;
   lastname: string;
+  email?: string;
 };
 const userDecoder = JsonDecoder.object<User>(
   {
     firstname: JsonDecoder.string,
-    lastname: JsonDecoder.string
+    lastname: JsonDecoder.string,
+    email: JsonDecoder.optional(JsonDecoder.string)
   },
   'User'
 );
@@ -421,20 +423,29 @@ const jsonOk = {
   firstname: 'Damien',
   lastname: 'Jurado'
 };
-userDecoder.decode(jsonOk);
+
+const jsonFullUser = {
+  firstname: 'Damien',
+  lastname: 'Jurado',
+  email: 'user@example.com'
+};
 
 const jsonKo = {
   firstname: null,
   lastname: 'Satie'
 };
+
 JsonDecoder.optional(userDecoder).decode(null);
-// Output: Ok<User | undefined>({value: undefined})
+// Output: Ok<User | undefined | null>({value: null})
 
 JsonDecoder.optional(userDecoder).decode(undefined);
-// Output: Ok<User | undefined>({value: undefined})
+// Output: Ok<User | undefined | null>({value: undefined})
 
-JsonDecoder.optional(userDecoder).decode(jsonObjectOk);
-// Output: Ok<User | undefined>({value: {firstname: 'Damien', lastname: 'Jurado'}})
+JsonDecoder.optional(userDecoder).decode(jsonOk);
+// Output: Ok<User | undefined | null>({value: {firstname: 'Damien', lastname: 'Jurado', email: undefined}})
+
+JsonDecoder.optional(userDecoder).decode(jsonFullUser);
+// Output: Ok<User | undefined | null>({value: {firstname: 'Damien', lastname: 'Jurado', email: 'user@example.com'}})
 
 JsonDecoder.optional(userDecoder).decode(jsonKo);
 // Output: Err({error: '<User> decoder failed at key "firstname" with error: null is not a valid string'})

--- a/src/json-decoder.spec.ts
+++ b/src/json-decoder.spec.ts
@@ -145,18 +145,25 @@ describe('json-decoder', () => {
     type User = {
       firstname: string;
       lastname: string;
+      email?: string;
     };
 
     const userDecoder = JsonDecoder.object<User>(
       {
         firstname: JsonDecoder.string,
-        lastname: JsonDecoder.string
+        lastname: JsonDecoder.string,
+        email: JsonDecoder.optional(JsonDecoder.string)
       },
       'User'
     );
     const user = {
       firstname: 'John',
       lastname: 'Doe'
+    };
+    const userWithEmail = {
+      firstname: 'John',
+      lastname: 'Doe',
+      email: 'user@example.com'
     };
 
     const badUserData = {
@@ -185,6 +192,15 @@ describe('json-decoder', () => {
       const result = JsonDecoder.optional(
         userDecoder
       ).decode(user);
+
+      expect(result).to.deep.equal(expectedSuccessResult);
+    });
+
+    it('should recursively decode optional values when a valid value is provided', () => {
+      const expectedSuccessResult = userDecoder.decode(userWithEmail);
+      const result = JsonDecoder.optional(
+        userDecoder
+      ).decode(userWithEmail);
 
       expect(result).to.deep.equal(expectedSuccessResult);
     });

--- a/src/json-decoder.spec.ts
+++ b/src/json-decoder.spec.ts
@@ -140,6 +140,65 @@ describe('json-decoder', () => {
     });
   });
 
+  // optional
+  describe('optional', () => {
+    type User = {
+      firstname: string;
+      lastname: string;
+    };
+
+    const userDecoder = JsonDecoder.object<User>(
+      {
+        firstname: JsonDecoder.string,
+        lastname: JsonDecoder.string
+      },
+      'User'
+    );
+    const user = {
+      firstname: 'John',
+      lastname: 'Doe'
+    };
+
+    const badUserData = {
+      firstname: 2,
+      lastname: 'Doe'
+    };
+
+    it('should decode a null value', () => {
+      expectOkWithValue(
+        JsonDecoder.optional(
+          userDecoder
+        ).decode(null),
+        undefined);
+    });
+
+    it('should decode an undefined value', () => {
+      expectOkWithValue(
+        JsonDecoder.optional(
+          userDecoder
+        ).decode(undefined),
+        undefined);
+    });
+
+    it('should decode the value when a valid value is provided', () => {
+      const expectedSuccessResult = userDecoder.decode(user);
+      const result = JsonDecoder.optional(
+        userDecoder
+      ).decode(user);
+
+      expect(result).to.deep.equal(expectedSuccessResult);
+    });
+
+    it('should fail with message from wrapped decoder when unable to decode object', () => {
+      const expectedErrorResult = userDecoder.decode(badUserData);
+      const result = JsonDecoder.optional(
+        userDecoder
+      ).decode(badUserData);
+
+      expect(result).to.deep.equal(expectedErrorResult);
+    });
+  });
+
   // oneOf
   describe('oneOf (union types)', () => {
     it('should pick the number decoder', () => {

--- a/src/json-decoder.ts
+++ b/src/json-decoder.ts
@@ -252,6 +252,27 @@ export namespace JsonDecoder {
   }
 
   /**
+   * Tries to decode with `decoder` and returns `error` on failure, but allows
+   * for `undefined` or `null` values to be present at the top level and returns
+   * an `undefined` if the value was `undefined` or `null`.
+   *
+   * @param decoder The actual decoder to use.
+   */
+  export function optional<a>(
+    decoder: Decoder<a>
+  ): Decoder<a|undefined> {
+    return new Decoder<a|undefined>((json: any) => {
+      if (json === undefined) {
+        return ok<undefined>(undefined);
+      } else if (json === null) {
+        return ok<undefined>(undefined);
+      } else {
+        return decoder.decode(json);
+      }
+    });
+  };
+
+  /**
    * Tries to decode the provided json value with any of the provided `decoders`.
    * If all provided `decoders` fail, this decoder fails.
    * Otherwise, it returns the first successful decoder.


### PR DESCRIPTION
Currently decoding an optional value entails using the `oneOf`
decoder, and passing in the decoder for the type you want decoded,
the `isUndefined(undefined)`, and `isNull(undefined)` to get an
optional value on an object.

The downside of doing this means that if you have an error on your
object, you lose the details of the error because the error becomes
`can't be decoded with any of the provided oneOf decoders` instead
of continuing the error trace down further down the structure to the
next oneOf decoders or the place where the decoding failed.