### PR TITLE
Fix README.md for JsonDecoder.optional section

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,16 +436,16 @@ const jsonKo = {
 };
 
 JsonDecoder.optional(userDecoder).decode(null);
-// Output: Ok<User | undefined | null>({value: null})
+// Output: Ok<User | undefined>({value: null})
 
 JsonDecoder.optional(userDecoder).decode(undefined);
-// Output: Ok<User | undefined | null>({value: undefined})
+// Output: Ok<User | undefined>({value: undefined})
 
 JsonDecoder.optional(userDecoder).decode(jsonOk);
-// Output: Ok<User | undefined | null>({value: {firstname: 'Damien', lastname: 'Jurado', email: undefined}})
+// Output: Ok<User | undefined>({value: {firstname: 'Damien', lastname: 'Jurado', email: undefined}})
 
 JsonDecoder.optional(userDecoder).decode(jsonFullUser);
-// Output: Ok<User | undefined | null>({value: {firstname: 'Damien', lastname: 'Jurado', email: 'user@example.com'}})
+// Output: Ok<User | undefined>({value: {firstname: 'Damien', lastname: 'Jurado', email: 'user@example.com'}})
 
 JsonDecoder.optional(userDecoder).decode(jsonKo);
 // Output: Err({error: '<User> decoder failed at key "firstname" with error: null is not a valid string'})

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ const jsonKo = {
 };
 
 JsonDecoder.optional(userDecoder).decode(null);
-// Output: Ok<User | undefined>({value: null})
+// Output: Ok<User | undefined>({value: undefined})
 
 JsonDecoder.optional(userDecoder).decode(undefined);
 // Output: Ok<User | undefined>({value: undefined})


### PR DESCRIPTION
The result types had the ` | null` in the results comments from
starting to add support for a `null` return type if passed in.

The previous change didn't go in with that version of the return
type, and missed removing it from the README.md, so this fixes
the examples.