### PR TITLE
Require all keys of an object decoder to be specified

### DIFF
--- a/src/json-decoder.ts
+++ b/src/json-decoder.ts
@@ -119,7 +119,7 @@ export namespace JsonDecoder {
     }
   });
 
-  export type DecoderObject<a> = { [p in keyof a]: Decoder<a[p]> };
+  export type DecoderObject<a> = { [p in keyof Required<a>]: Decoder<a[p]> };
   export type DecoderObjectKeyMap<a> = { [p in keyof a]?: string };
 
   /**


### PR DESCRIPTION
This change requires all keys of an object decoder to be specified, even if they are optional.
At the moment this would compile without an error:
```typescript
    type User = {
      firstname: string;
      lastname: string;
      email?: string;
    };

    const userDecoder = JsonDecoder.object<User>(
      {
        firstname: JsonDecoder.string,
        lastname: JsonDecoder.string
      },
      'User'
    );
```
I like the idea of adding a new optional property and being forced to be specific about the way it's being decoded. Most of the time I probably want
```
    email: JsonDecoder.optional(JsonDecoder.string)
```
If I want it to be ignored, I could use
```
    email: JsonDecoder.constant<undefined>(undefined),
```
Does this make sense?