### PR TITLE
Add a nullable decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,36 @@ treeDecoder.decode({
 
 The `optional` decoder tries to decode the provided JSON with the provided decoder if the json value is not `undefined` or `null`. This decoder is to allow for an optional value in the TypeScript definition while retaining the ability to give a detailed error message if the wrapped decoder fails.
 
+### JsonDecoder.nullable
+
+> `nullable<a>(decoder: Decoder<a>): Decoder<a | null>`
+
+The `nullable` decoder tries to decode the provided JSON with the provided decoder, but allows for `null` value. It returns a detailed error message if the value is not `null` and the wrapped decoder fails.
+
+```ts
+interface User {
+  name: string;
+  email: string | null;
+}
+
+const userDecoder = JsonDecoder.object<User>(
+  {
+    name: JsonDecoder.string,
+    email: JsonDecoder.nullable(JsonDecoder.string)
+  },
+  'User'
+);
+
+userDecoder.decode({ name: 'Alice', email: 'alice@example.com' })
+// Output: Ok<User>({value: {name: 'Alice', email: 'alice@example.com'}})
+
+userDecoder.decode({ name: 'Alice', email: null })
+// Output: Ok<User>({value: {name: 'Alice', email: null}})
+
+userDecoder.decode({ name: 'Alice' })
+// Output: Err({error: "<User> decoder failed at key 'email' with error: undefined is not a valid string"})
+```
+
 #### @param `decoder: Decoder<a>`
 
 Decoder the JSON will be decoded with if the value is not `null` or `undefined`.

--- a/src/json-decoder.spec.ts
+++ b/src/json-decoder.spec.ts
@@ -207,6 +207,39 @@ describe('json-decoder', () => {
     });
   });
 
+  // nullable
+  describe('nullable', () => {
+    const nullableStringDecoder = JsonDecoder.nullable(JsonDecoder.string);
+
+    it('should decode a null value', () => {
+      expectOkWithValue(
+        nullableStringDecoder.decode(null),
+        null
+      );
+    });
+
+    it('should decode an actual value', () => {
+      expectOkWithValue(
+        nullableStringDecoder.decode('a string'),
+        'a string'
+      );
+    });
+
+    it('should fail on undefined value', () => {
+      const expectedErrorResult = JsonDecoder.string.decode(undefined);
+      const result = nullableStringDecoder.decode(undefined);
+
+      expect(result).to.deep.equal(expectedErrorResult);
+    });
+
+    it('should fail with message from wrapped decoder when unable to decode object', () => {
+      const expectedErrorResult = JsonDecoder.string.decode(1);
+      const result = nullableStringDecoder.decode(1);
+
+      expect(result).to.deep.equal(expectedErrorResult);
+    });
+  });
+
   // oneOf
   describe('oneOf (union types)', () => {
     it('should pick the number decoder', () => {

--- a/src/json-decoder.ts
+++ b/src/json-decoder.ts
@@ -271,6 +271,20 @@ export namespace JsonDecoder {
   }
 
   /**
+   * Tries to decode with `decoder` and returns `error` on failure, but allows for `null` value.
+   *
+   * @param decoder The actual decoder to use
+   */
+  export function nullable<a>(decoder: Decoder<a>): Decoder<a | null> {
+    return new Decoder<a | null>((json: any) => {
+      if (json === null) {
+        return ok(null);
+      }
+      return decoder.decode(json);
+    });
+  }
+
+  /**
    * Tries to decode the provided json value with any of the provided `decoders`.
    * If all provided `decoders` fail, this decoder fails.
    * Otherwise, it returns the first successful decoder.


### PR DESCRIPTION
In the application I'm currently working on lots of interfaces contain attributes of `T | null` type. At the same type these attributes are not optional and should be presented. I wrote a helper decoder for that purpose and decided that it might be useful in the original library, too.

An example:

```ts
interface User {
  name: string;
  email: string | null;
}

const userDecoder = JsonDecoder.object<User>(
  {
    name: JsonDecoder.string,
    email: JsonDecoder.nullable(JsonDecoder.string)
  },
  'User'
);

userDecoder.decode({ name: 'Alice', email: 'alice@example.com' })
// Output: Ok<User>({value: {name: 'Alice', email: 'alice@example.com'}})

userDecoder.decode({ name: 'Alice', email: null })
// Output: Ok<User>({value: {name: 'Alice', email: null}})

userDecoder.decode({ name: 'Alice' })
// Output: Err({error: "<User> decoder failed at key 'email' with error: undefined is not a valid string"})
```