### PR TITLE
Combine decoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,13 +421,13 @@ const userDecoder = JsonDecoder.object<User>(
   'User'
 );
 
-userDecoder.decode({ name: 'Alice', email: 'alice@example.com' })
+userDecoder.decode({ name: 'Alice', email: 'alice@example.com' });
 // Output: Ok<User>({value: {name: 'Alice', email: 'alice@example.com'}})
 
-userDecoder.decode({ name: 'Alice', email: null })
+userDecoder.decode({ name: 'Alice', email: null });
 // Output: Ok<User>({value: {name: 'Alice', email: null}})
 
-userDecoder.decode({ name: 'Alice' })
+userDecoder.decode({ name: 'Alice' });
 // Output: Err({error: "<User> decoder failed at key 'email' with error: undefined is not a valid string"})
 ```
 
@@ -598,6 +598,42 @@ Value always returned.
 ```ts
 JsonDecoder.constant(true).decode(false);
 // Ok({value: true})
+```
+
+### JsonDecoder.combine
+
+A `combine` decoder tries to decode the provided JSON with all of the provided decoders and returns an intersection of them all.
+
+Value always returned.
+
+```ts
+type User = { id: string };
+type WithName = { name: string };
+type WithAge = { age: number };
+
+const userDecoder = JsonDecoder.object<User>(
+  { id: JsonDecoder.string },
+  'User'
+);
+
+const nameDecoder = JsonDecoder.object<WithName>(
+  { name: JsonDecoder.string },
+  'WithName'
+);
+
+const ageDecoder = JsonDecoder.object<WithAge>(
+  { age: JsonDecoder.number },
+  'WithAge'
+);
+
+const finalDecoder = JsonDecoder.combine(userDecoder, nameDecoder, ageDecoder);
+// Decoder<User & WithName & WithAge>
+
+finalDecoder.decode({ id: 'alice', name: 'Alice', age: 30 });
+// Ok({ id: 'alice', name: 'Alice', age: 30 })
+
+finalDecoder.decode({ id: 'alice' });
+// Err({ error: '<WithName> decoder failed at key "name" with error: undefined is not a valid string' })
 ```
 
 ## Related libraries

--- a/src/json-decoder.spec.ts
+++ b/src/json-decoder.spec.ts
@@ -822,6 +822,41 @@ describe('json-decoder', () => {
     });
   });
 
+  // combine
+  describe('combine', () => {
+    type WithName = { name: string };
+    type WithAge = { age: number };
+
+    const nameDecoder = JsonDecoder.object<WithName>(
+      { name: JsonDecoder.string },
+      'WithName'
+    );
+
+    const ageDecoder = JsonDecoder.object<WithAge>(
+      { age: JsonDecoder.number },
+      'WithAge'
+    );
+
+    const combinedDecoder = JsonDecoder.combine(nameDecoder, ageDecoder);
+
+    it('creates decoder that succeeds when both decoders succeed', () => {
+      const data = { name: 'Alice', age: 30 };
+      expectOkWithValue(combinedDecoder.decode(data), data);
+    });
+
+    it('creates decoder that fails when at least of of the decoders failed', () => {
+      expectErrWithMsg(
+        combinedDecoder.decode({ age: 30 }),
+        `<WithName> decoder failed at key "name" with error: undefined is not a valid string`
+      );
+
+      expectErrWithMsg(
+        combinedDecoder.decode({ name: 'Alice' }),
+        `<WithAge> decoder failed at key "age" with error: undefined is not a valid number`
+      );
+    });
+  });
+
   // Mixed
   describe('complex combinations', () => {
     type User = {

--- a/src/json-decoder.ts
+++ b/src/json-decoder.ts
@@ -506,7 +506,7 @@ export namespace JsonDecoder {
    *
    *    { x: number } & { y: number }
    */
-  export type Intersect<T> = (T extends any ? (x: T) => void : never) extends (
+  type Intersect<T> = (T extends any ? (x: T) => void : never) extends (
     x: infer R
   ) => void
     ? R
@@ -523,7 +523,7 @@ export namespace JsonDecoder {
    *
    *    { x: number } & { y: number }
    */
-  export type Combine<T extends { [k: string]: any }[]> = Intersect<T[number]>;
+  type Combine<T extends { [k: string]: any }[]> = Intersect<T[number]>;
 
   /**
    * Combines a list of decoders into a single decoder

--- a/src/json-decoder.ts
+++ b/src/json-decoder.ts
@@ -494,6 +494,69 @@ export namespace JsonDecoder {
       }
     });
   }
+
+  /**
+   * Transforms union type to intersection type.
+   *
+   * For example:
+   *
+   *    Intersect<{ x: number } | { y: number }>
+   *
+   * becomes
+   *
+   *    { x: number } & { y: number }
+   */
+  export type Intersect<T> = (T extends any ? (x: T) => void : never) extends (
+    x: infer R
+  ) => void
+    ? R
+    : never;
+
+  /**
+   * Transforms array of objects to a combined intersection type
+   *
+   * For example:
+   *
+   *    Combine<[{ x: number }, { y: number }]>
+   *
+   * becomes
+   *
+   *    { x: number } & { y: number }
+   */
+  export type Combine<T extends { [k: string]: any }[]> = Intersect<T[number]>;
+
+  /**
+   * Combines a list of decoders into a single decoder
+   * which result is an intersection type of input decoders.
+   *
+   * Example:
+   *
+   *    > JsonDecoder.combine(Decoder<User>, Decoder<Metadata>)
+   *    // => Decoder<User & Metadata>
+   *
+   * @param decoders Variable arguments list of decoders
+   */
+  export function combine<TS extends { [k: string]: any }[]>(
+    ...decoders: { [T in keyof TS]: Decoder<TS[T]> }
+  ): Decoder<Combine<TS>> {
+    return new Decoder((json: any) => {
+      try {
+        const finalResult = decoders.reduce((acc, decoder) => {
+          const result = decoder.decode(json);
+          if (result.isOk()) {
+            return {
+              ...acc,
+              ...result.value
+            };
+          }
+          throw result.error;
+        }, {}) as Combine<TS>;
+        return ok(finalResult);
+      } catch (error) {
+        return err(error);
+      }
+    });
+  }
 }
 
 export namespace $JsonDecoderErrors {


### PR DESCRIPTION
I've added a `JsonDecoder.combine(decoderA, decoderB, ...)` function that allows to easily write decoders for intersection types.

## Example

```ts
// Define basic types
type User = { name: string };
type Post = { title: string };
type Metadata = { id: number };

// Define basic decoders
const UserDecoder = JsonDecoder.object<User>(
  { name: JsonDecoder.string },
  'User'
);

const PostDecoder = JsonDecoder.object<Post>(
  { title: JsonDecoder.string },
  'Post'
);

const MetadataDecoder = JsonDecoder.object<Metadata>(
  { id: JsonDecoder.number },
  'Metadata'
);

// Define combined types and decoders
type UserWithMetadata = User & Metadata;
type PostWithMetadata = Post & Metadata;

const UserWithMetadataDecoder = JsonDecoder.combine(
  UserDecoder,
  MetadataDecoder
);

const PostWithMetadataDecoder = JsonDecoder.combine(
  PostDecoder,
  MetadataDecoder
);

```