### PR TITLE
feat: Add new mapError transformer

### DIFF
--- a/src/json-decoder.spec.ts
+++ b/src/json-decoder.spec.ts
@@ -1228,6 +1228,23 @@ describe('json-decoder', () => {
         ]);
       });
     });
+
+    describe('mapError', () => {
+      const numberWithMapErrorToNull = JsonDecoder.number.mapError(() => null)
+      const numberWithMapErrorToErrorMessage = JsonDecoder.number.mapError((error) => error)
+      
+      it('should decode successfully', () => {
+        expectOkWithValue(numberWithMapErrorToNull.decode(9), 9);
+      });
+
+      it('should transform the value when decoding fails', () => {
+        expectOkWithValue(numberWithMapErrorToNull.decode("not a number"), null);
+      });
+
+      it('should provide the callback function with the error message', () => {
+        expectOkWithValue(numberWithMapErrorToErrorMessage.decode("not a number"), "\"not a number\" is not a valid number");
+      });
+    });
   });
 
   describe('readme examples', () => {

--- a/src/json-decoder.ts
+++ b/src/json-decoder.ts
@@ -62,6 +62,21 @@ export namespace JsonDecoder {
     }
 
     /**
+     * Chains decoder error transformations
+     * @param fn The transformation function
+     */
+    mapError<b>(fn: (error: string) => b): Decoder<a | b> {
+      return new Decoder<a | b>((json: any) => {
+        const result = this.decodeFn(json);
+        if (result.isOk()) {
+          return ok<a>(result.value);
+        } else {
+          return ok<b>(fn(result.error));
+        }
+      });
+    }
+
+    /**
      * Chains decoders
      * @param fn Function that returns a new decoder
      */
@@ -605,7 +620,7 @@ export namespace $JsonDecoderErrors {
 
   export const enumValueError = (
     decoderName: string,
-    invalidValue: any,
+    invalidValue: any
   ): string =>
     `<${decoderName}> decoder failed at value "${invalidValue}" which is not in the enum`;
 

--- a/src/json-decoder.ts
+++ b/src/json-decoder.ts
@@ -62,7 +62,7 @@ export namespace JsonDecoder {
     }
 
     /**
-     * Chains decoder error transformations
+     * Transforms an error into a new value
      * @param fn The transformation function
      */
     mapError<b>(fn: (error: string) => b): Decoder<a | b> {
@@ -620,7 +620,7 @@ export namespace $JsonDecoderErrors {
 
   export const enumValueError = (
     decoderName: string,
-    invalidValue: any
+    invalidValue: any,
   ): string =>
     `<${decoderName}> decoder failed at value "${invalidValue}" which is not in the enum`;
 


### PR DESCRIPTION
## mapError

Transforms an error into a value.

```tsx
const decoder = JsonDecoder.number.mapError((error) => {
    console.warn(error)
    return 0
})

decoder.decode(10) // Ok<10>
decoder.decode("fail") // Ok<0> and "Warning: "fail" is not a number" in console

```

