### PR TITLE
Fix parsing enums with items evaluating to 0

### DIFF
--- a/src/json-decoder.spec.ts
+++ b/src/json-decoder.spec.ts
@@ -98,7 +98,8 @@ describe('json-decoder', () => {
     enum OddlyOrderedIntEnum {
       A = 2,
       B = 8,
-      C = -3
+      C = -3,
+      D = 0,
     }
     enum HeterogeneousEnum {
       X = 1,
@@ -116,6 +117,13 @@ describe('json-decoder', () => {
           'OddlyOrderedIntEnum'
         ).decode(-3),
         OddlyOrderedIntEnum.C /* -3 */
+      );
+      expectOkWithValue(
+        JsonDecoder.enumeration<OddlyOrderedIntEnum>(
+          OddlyOrderedIntEnum,
+          'OddlyOrderedIntEnum'
+        ).decode(0),
+        OddlyOrderedIntEnum.D /* 0 */
       );
       expectOkWithValue(
         JsonDecoder.enumeration<HeterogeneousEnum>(

--- a/src/json-decoder.ts
+++ b/src/json-decoder.ts
@@ -148,7 +148,7 @@ export namespace JsonDecoder {
   ): Decoder<e> {
     return new Decoder<e>((json: any) => {
       const enumValue = Object.values(enumObj).find((x: any) => x === json);
-      if (enumValue) {
+      if (enumValue !== undefined) {
         return ok<e>(enumValue);
       }
       return err<e>($JsonDecoderErrors.enumValueError(decoderName, json));


### PR DESCRIPTION
I have a typescript like this:

```typescript
enum MyEnum {
    Name0 = 0,
    Name1 = 1,
    Name2 = 2,
}
interface MyInterface
{
    fieldName: MyEnum 
}
const decoder = JsonDecoder.objectStrict<MyInterface>(
    {
        fieldName: JsonDecoder.enumeration<MyEnum>(MyEnum , 'MyEnum'),
    },
    'MyDecoder'
);
```

When checking a json like this:

```json
{
   "fieldName": 0
}
```

The code fails, since the result of `Object.values(enumObj).find((x: any) => x === json);` is `0`.

Since `find` returns `undefined` if the value can't be found, what about using it?